### PR TITLE
copywrite: ignore madmin

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,11 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2025
+
+  header_ignore = [
+    # ignoring Minio's apache licensed code that is used as is in this repo
+    "madmin/**",
+  ]
+}


### PR DESCRIPTION
I noticed #30 which should not contain our copywrite headers